### PR TITLE
fix task dependencies and add link to account identifier docs

### DIFF
--- a/.devcontainer/config
+++ b/.devcontainer/config
@@ -1,6 +1,7 @@
 # SnowSQL config
 
 [connections.dev]
+# See https://docs.snowflake.com/en/user-guide/admin-account-identifier.
 accountname = myaccount
 username = myusername
 password = mypassword

--- a/steps/07_deploy_task_dag.py
+++ b/steps/07_deploy_task_dag.py
@@ -64,8 +64,8 @@ def main(session: Session) -> str:
         dag_task2 = DAGTask("LOAD_LOCATION_TASK", definition="CALL LOAD_EXCEL_WORKSHEET_TO_TABLE_SP(BUILD_SCOPED_FILE_URL(@FROSTBYTE_RAW_STAGE, 'intro/location.xlsx'), 'location', 'LOCATION')", warehouse=warehouse_name)
         dag_task3 = DAGTask("LOAD_DAILY_CITY_METRICS_TASK", definition="CALL LOAD_DAILY_CITY_METRICS_SP()", warehouse=warehouse_name)
 
-        dag_task2 >> dag_task1
-        dag_task3 >> dag_task2
+        dag_task1 >> dag_task3
+        dag_task2 >> dag_task3
 
     # Create the DAG in Snowflake
     schema = api_root.databases[database_name].schemas[schema_name]


### PR DESCRIPTION
## Fix task dependencies in the code

The `__rshift__` operator on a `DAGTask` is defined as syntactic sugar for `add_successors`, meaning that `dag_task3 >> dag_task2` will cause `LOAD_DAILY_CITY_METRICS_TASK` to run *before* and not *after* `LOAD_LOCATION_TASK`.

Furthermore, there is no need to create a dependency between `LOAD_ORDER_DETAIL_TASK` and `LOAD_LOCATION_TASK`. It was probably meant to be a dependency between the data load task and the metrics calculation task.

This commit fixes both issues and I have confimed that the task graph looks like [the screenshot in the script](https://github.com/Snowflake-Labs/sfquickstarts/blob/master/site/sfguides/src/data_engineering_with_snowpark_python_intro/assets/tasks_and_dags.png).

## Link to account identifier docs

Some obvious things might not work:
- just the account name
- account identifier as copied over from the UI (it contains a dot rather than a hyphen as it's meant for SQL operations)

What *does* work is `<orgname>-<account_name>` or the account locator, although it's not recommended.